### PR TITLE
Fix type in OCILobIsTemporary function call

### DIFF
--- a/cx_Oracle/lobvar.py
+++ b/cx_Oracle/lobvar.py
@@ -61,7 +61,7 @@ class BaseLobVariableType(VariableType):
         
         for i in xrange(var.allocelems):
             if typed_data[i]:
-                c_is_temporary = ctypes.c_long()
+                c_is_temporary = ctypes.c_int()
                 status = oci.OCILobIsTemporary(var.environment.handle,
                         var.environment.error_handle, typed_data[i], byref(c_is_temporary))
                 var.environment.check_for_error(status, "LobVar_PreFetch(): is temporary LOB?")
@@ -76,7 +76,7 @@ class BaseLobVariableType(VariableType):
     def set_value(self, var, pos, value):
         # make sure have temporary LOBs set up
         typed_data = self.get_typed_data(var)
-        c_is_temporary = ctypes.c_long()
+        c_is_temporary = ctypes.c_int()
         status = oci.OCILobIsTemporary(var.environment.handle, var.environment.error_handle,
                                        typed_data[pos], byref(c_is_temporary))
         var.environment.check_for_error(status, "LobVar_SetValue(): is temporary?")


### PR DESCRIPTION
Fourth argument of OCILobIsTemporary is declared as boolean*,
while boolean is same as ctypes.c_int in both oci_generated_10.py and
oci_generated_11.py.

Example traceback for this issue(can be reproduced by selecting CLOB row):
Traceback (most recent call last):
  File "app_main.py", line 75, in run_toplevel
  File "test.py", line 18, in <module>
    for row in cur:
  File "/usr/lib64/pypy-2.4.0/site-packages/cx_Oracle/cursor.py", line 698, in next
    more_rows_available = self.more_rows()
  File "/usr/lib64/pypy-2.4.0/site-packages/cx_Oracle/cursor.py", line 456, in more_rows
    self.internal_fetch(self.fetch_array_size)
  File "/usr/lib64/pypy-2.4.0/site-packages/cx_Oracle/cursor.py", line 415, in internal_fetch
    var.type.pre_fetch_proc(var)
  File "/usr/lib64/pypy-2.4.0/site-packages/cx_Oracle/lobvar.py", line 66, in pre_fetch
    var.environment.error_handle, typed_data[i], byref(c_is_temporary))
  File "/usr/lib64/pypy-2.4.0/lib_pypy/_ctypes/function.py", line 712, in __call__
    return CFuncPtr.__call__(self, *args)
  File "/usr/lib64/pypy-2.4.0/lib_pypy/_ctypes/function.py", line 342, in __call__
    self._convert_args(argtypes, args, kwargs))
  File "/usr/lib64/pypy-2.4.0/lib_pypy/_ctypes/function.py", line 571, in _convert_args
    raise ArgumentError(str(e))
ArgumentError: expected LP_c_int instance instead of LP_c_long
