### PR TITLE
Avoid race condition on oci function argument wrapping

### DIFF
--- a/cx_Oracle/oci.py
+++ b/cx_Oracle/oci.py
@@ -53,3 +53,7 @@ def OCIDateGetTime(date):
 def OCIDateSetTime(date, hour, minute, second):
     time = date.OCIDateTime
     time.OCITimeHH, time.OCITimeMI, time.OCITimeSS = hour, minute, second
+
+class AnythingGoes(object):
+    def from_param(self, val):
+        return val

--- a/cx_Oracle/utils.py
+++ b/cx_Oracle/utils.py
@@ -45,15 +45,3 @@ MAX_BINARY_BYTES = 4000
 class AnythingGoes(object):
     def from_param(self, val):
         return val
-
-class ReplaceArgtypeByVoidPointerContextManager(object):
-    def __init__(self, oci_function, pos):
-        self.oci_function = oci_function
-        self.pos = pos
-    
-    def __enter__(self):
-        self.old_argtypes = self.oci_function.argtypes
-        self.oci_function.argtypes = self.old_argtypes[:self.pos] + [AnythingGoes()] + self.old_argtypes[self.pos+1:]
-        
-    def __exit__(self):
-        self.oci_function.argtypes = self.old_argtypes


### PR DESCRIPTION
Previous implementation could fail in following ways in
multi-thread environment:
Scenario #1 - one-time failure:
t1 changes arguments of OCIHandleAlloc;
t2 calls oci.OCIHandleAlloc(), expecting to call original one, fails
with exception;
t1 restores arguments of OCIHandleAlloc.

Scenario #2 - failure till process restart:
t1 changes arguments of OCIHandleAlloc to wrapped(o->w1);
t2 changes arguments of OCIHandleAlloc to new wrapped(w1->w2);
t1 restores arguments of OCIHandleAlloc to original(w1->o);
t2 restores arguments of OCIHandleAlloc to wrapped(w2->w1).
As a result, original args for OCIHandleAlloc are nowhere to be found
and library fails to connect to DB.

Proposed solution is to create copies of args instead of modifying
global state.